### PR TITLE
Za Warudo (time scaling fix)

### DIFF
--- a/recipes.json
+++ b/recipes.json
@@ -6,7 +6,7 @@
  "subcategory": "CSC_ARMOR_SUIT",
  "skill_used": "tailor",
  "difficulty": 4,
- "time": 200000,
+ "time": "200 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -27,7 +27,7 @@
  "subcategory": "CSC_ARMOR_SUIT",
  "skill_used": "tailor",
  "difficulty": 4,
- "time": 180000,
+ "time": "180 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -49,7 +49,7 @@
   "skill_used": "tailor",
   "skills_required" : ["fabrication", 6],
   "difficulty": 7,
-  "time": 120000,
+  "time": "120 m",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -101,7 +101,7 @@
  "subcategory": "CSC_ARMOR_SUIT",
  "skill_used": "tailor",
  "difficulty": 4,
- "time": 200000,
+ "time": "200 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -122,7 +122,7 @@
  "subcategory": "CSC_ARMOR_HEAD",
  "skill_used": "tailor",
  "difficulty": 4,
- "time": 60000,
+ "time": "60 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -143,7 +143,7 @@
   "subcategory": "CSC_ARMOR_FEET",
   "skill_used": "tailor",
   "difficulty": 5,
-  "time": 100000,
+  "time": "100 m",
   "reversible": false,
   "autolearn": true,
   "tools": [
@@ -164,7 +164,7 @@
   "subcategory": "CSC_ARMOR_FEET",
   "skill_used": "tailor",
   "difficulty": 4,
-  "time": 80000,
+  "time": "80 m",
   "reversible": false,
   "autolearn": true,
   "tools": [
@@ -185,7 +185,7 @@
  "subcategory": "CSC_ARMOR_SUIT",
  "skill_used": "tailor",
  "difficulty": 4,
- "time": 200000,
+ "time": "200 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -207,7 +207,7 @@
   "skill_used": "tailor",
   "skills_required" : ["fabrication", 6],
   "difficulty": 7,
-  "time": 120000,
+  "time": "120 m",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -260,7 +260,7 @@
   "skill_used": "fabrication",
   "difficulty": 3,
   "skills_required" : [ "throw", 4 ],
-  "time": 20000,
+  "time": "20 m",
   "reversible": false,
   "autolearn": true,
   "qualities":[
@@ -290,7 +290,7 @@
   "skill_used": "fabrication",
   "difficulty": 7,
   "skills_required" : [ "throw", 7 ],
-  "time": 240000,
+  "time": "240 m",
   "reversible": false,
   "autolearn": true,
   "qualities":[
@@ -331,7 +331,7 @@
   "skill_used": "fabrication",
   "difficulty": 7,
   "skills_required" : [ "throw", 7 ],
-  "time": 20000,
+  "time": "20 m",
   "reversible": false,
   "autolearn": true,
   "qualities":[
@@ -376,7 +376,7 @@
   "skill_used": "fabrication",
   "difficulty": 10,
   "skills_required" : [ "melee", 10 ],
-  "time": 480000,
+  "time": "480 m",
   "reversible": false,
   "autolearn": true,
   "qualities": [
@@ -425,7 +425,7 @@
   "skill_used": "fabrication",
   "difficulty": 9,
   "skills_required" : [ "melee", 7 ],
-  "time": 480000,
+  "time": "480 m",
   "reversible": false,
   "autolearn": true,
   "qualities": [
@@ -477,7 +477,7 @@
   "skill_used": "fabrication",
   "difficulty": 6,
   "skills_required" : [ "melee", 6 ],
-  "time": 5000,
+  "time": "5 m",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -525,7 +525,7 @@
   "skill_used": "fabrication",
   "difficulty": 8,
   "skills_required" : [ "melee", 6 ],
-  "time": 360000,
+  "time": "360 m",
   "reversible": false,
   "autolearn": true,
   "qualities": [
@@ -575,7 +575,7 @@
   "skill_used": "fabrication",
   "difficulty": 8,
   "skills_required" : [ "melee", 6 ],
-  "time": 480000,
+  "time": "480 m",
   "reversible": false,
   "autolearn": true,
   "qualities": [
@@ -621,7 +621,7 @@
   "skill_used": "fabrication",
   "difficulty": 8,
   "skills_required" : [ "melee", 6 ],
-  "time": 540000,
+  "time": "540 m",
   "reversible": false,
   "autolearn": true,
   "qualities": [
@@ -673,7 +673,7 @@
   "subcategory": "CSC_ARMOR_OTHER",
   "skill_used": "tailor",
   "difficulty": 3,
-  "time": 10000,
+  "time": "10 m",
   "reversible": false,
   "autolearn": true,
   "components": [
@@ -695,7 +695,7 @@
   "subcategory": "CSC_ARMOR_OTHER",
   "skill_used": "tailor",
   "difficulty": 3,
-  "time": 10000,
+  "time": "10 m",
   "reversible": false,
   "autolearn": true,
   "components": [
@@ -717,7 +717,7 @@
   "subcategory": "CSC_ARMOR_OTHER",
   "skill_used": "cooking",
   "difficulty": 8,
-  "time": 400000,
+  "time": "400 m",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -739,7 +739,7 @@
     "subcategory": "CSC_AMMO_OTHER",
     "skill_used": "cooking",
     "difficulty": 0,
-    "time": 1000,
+    "time": "1 m",
     "reversible": false,
     "autolearn": true,
     "qualities" : [
@@ -758,7 +758,7 @@
  "category": "CC_OTHER",
  "skill_used": "cooking",
  "difficulty": 9,
- "time": 100000,
+ "time": "100 m",
  "reversible": false,
  "autolearn": false,
  "book_learn": [[ "book_shoggoth", 9 ]],
@@ -792,7 +792,7 @@
  "subcategory": "CSC_ARMOR_OTHER",
  "skill_used": "tailor",
  "difficulty": 4,
- "time": 200000,
+ "time": "200 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -819,7 +819,7 @@
  "subcategory": "CSC_ARMOR_HEAD",
  "skill_used": "tailor",
  "difficulty": 3,
- "time": 20000,
+ "time": "20 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -840,7 +840,7 @@
  "subcategory": "CSC_ARMOR_HEAD",
  "skill_used": "tailor",
  "difficulty": 5,
- "time": 40000,
+ "time": "40 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -861,7 +861,7 @@
  "skill_used": "fabrication",
  "skills_required": [ "tailor", 3 ],
  "difficulty": 3,
- "time": 60000,
+ "time": "60 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -882,7 +882,7 @@
  "skill_used": "fabrication",
  "skills_required": [ "tailor", 3 ],
  "difficulty": 3,
- "time": 60000,
+ "time": "60 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -907,7 +907,7 @@
  "skill_used": "fabrication",
  "skills_required": [ "tailor", 3 ],
  "difficulty": 3,
- "time": 60000,
+ "time": "60 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -932,7 +932,7 @@
  "subcategory": "CSC_AMMO_OTHER",
  "skill_used": "fabrication",
  "difficulty": 0,
- "time": 30000,
+ "time": "30 m",
  "flags": ["BLIND_EASY"],
  "reversible": false,
  "autolearn": true,
@@ -955,7 +955,7 @@
   "subcategory": "CSC_ARMOR_SUIT",
   "skill_used": "tailor",
   "difficulty": 8,
-  "time": 25000,
+  "time": "25 m",
   "reversible": true,
   "autolearn": true,
   "tools": [
@@ -981,7 +981,7 @@
   "skill_used": "fabrication",
   "difficulty": 7,
   "skills_required" : [ "melee", 6 ],
-  "time": 100000,
+  "time": "100 m",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -1029,7 +1029,7 @@
  "subcategory": "CSC_ARMOR_HEAD",
  "skill_used": "tailor",
  "difficulty": 8,
- "time": 120000,
+ "time": "120 m",
  "reversible": false,
  "autolearn": true,
  "tools": [
@@ -1071,7 +1071,7 @@
   "subcategory": "CSC_OTHER_TOOLS",
   "skill_used": "fabrication",
   "difficulty": 3,
-  "time": 20000,
+  "time": "20 m",
   "reversible": false,
   "autolearn": true,
   "qualities":[ {"id":"CUT","level":1,"amount":1} ],
@@ -1103,7 +1103,7 @@
   "subcategory": "CSC_OTHER_TOOLS",
   "skill_used": "fabrication",
   "difficulty": 2,
-  "time": 20000,
+  "time": "20 m",
   "reversible": false,
   "autolearn": true,
   "qualities":[ {"id":"CUT","level":1,"amount":1} ],
@@ -1134,7 +1134,7 @@
   "subcategory": "CSC_OTHER_TOOLS",
   "skill_used": "fabrication",
   "difficulty": 0,
-  "time": 300,
+  "time": "3 m",
   "reversible": false,
   "autolearn": true,
   "tools": [
@@ -1156,7 +1156,7 @@
   "skill_used": "fabrication",
   "difficulty": 4,
   "skills_required" : [ "cooking", 4 ],
-  "time": 5000,
+  "time": "5 m",
   "reversible": false,
   "autolearn": true,
   "components": [
@@ -1179,7 +1179,7 @@
   "subcategory": "CSC_OTHER_TOOLS",
   "skill_used": "fabrication",
   "difficulty": 3,
-  "time": 20000,
+  "time": "20 m",
   "reversible": false,
   "autolearn": true,
   "qualities":[ {"id":"CUT","level":1,"amount":1} ],
@@ -1212,7 +1212,7 @@
   "skill_used": "fabrication",
   "difficulty": 0,
   "skills_required" : [ "cooking", 3 ],
-  "time": 100,
+  "time": "1 s",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -1239,7 +1239,7 @@
   "skill_used": "fabrication",
   "difficulty": 0,
   "skills_required" : [ "cooking", 3 ],
-  "time": 100,
+  "time": "1 s",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -1266,7 +1266,7 @@
   "skill_used": "fabrication",
   "difficulty": 0,
   "skills_required" : [ "cooking", 3 ],
-  "time": 100,
+  "time": "1 s",
   "reversible": false,
   "autolearn": false,
   "book_learn": [[ "cookbook_human", 4 ]],
@@ -1293,7 +1293,7 @@
   "subcategory": "CSC_OTHER_TOOLS",
   "skill_used": "cooking",
   "difficulty": 3,
-  "time": 15000,
+  "time": "15 m",
   "reversible": false,
   "autolearn": true,
   "qualities" : [
@@ -1323,7 +1323,7 @@
   "subcategory": "CSC_OTHER_TOOLS",
   "skill_used": "fabrication",
   "difficulty": 2,
-  "time": 20000,
+  "time": "20 m",
   "reversible": true,
   "autolearn": true,
   "qualities" : [
@@ -1355,7 +1355,7 @@
   "subcategory": "CSC_ARMOR_LEGS",
   "skill_used": "tailor",
   "difficulty": 2,
-  "time": 35000,
+  "time": "35 m",
   "reversible": false,
   "autolearn": true,
   "tools": [
@@ -1375,7 +1375,7 @@
   "subcategory": "CSC_ARMOR_LEGS",
   "skill_used": "tailor",
   "difficulty": 2,
-  "time": 35000,
+  "time": "35 m",
   "reversible": false,
   "autolearn": true,
   "tools": [


### PR DESCRIPTION
*Quietly ignore mispeling the Jojo reference first time around*

Updated the time used for recipes since turn length got changed, as now seconds and minutes can be specified outright instead of using turns.